### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,13 +10,16 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 DiffEqBase = "6.62"
+ExplicitImports = "1.10"
 GeometricIntegrators = "0.6, 0.9"
 Reexport = "0.2, 1"
 julia = "1.6"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ODEProblemLibrary", "Test"]
+test = ["ExplicitImports", "ODEProblemLibrary", "RecursiveArrayTools", "Test"]

--- a/src/GeometricIntegratorsDiffEq.jl
+++ b/src/GeometricIntegratorsDiffEq.jl
@@ -1,8 +1,9 @@
 module GeometricIntegratorsDiffEq
 
-using Reexport
+using Reexport: @reexport
 @reexport using DiffEqBase
 
+using DiffEqBase: check_keywords, warn_compat
 using GeometricIntegrators
 
 const warnkeywords = (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,16 @@
 using GeometricIntegratorsDiffEq
 using Test
+using ExplicitImports
 
-using GeometricIntegrators
+using RecursiveArrayTools: ArrayPartition
 import ODEProblemLibrary: prob_ode_2Dlinear
+
+@testset "Explicit Imports" begin
+    @test check_no_stale_explicit_imports(GeometricIntegratorsDiffEq) === nothing
+    # Note: check_no_implicit_imports is skipped because GeometricIntegrators
+    # exports vary between versions (0.6.x vs 0.9.x) and we intentionally use
+    # `using GeometricIntegrators` to get all exports from the installed version.
+end
 
 prob = prob_ode_2Dlinear
 


### PR DESCRIPTION
## Summary
- Add explicit import for `@reexport` from Reexport
- Add explicit imports for `check_keywords` and `warn_compat` from DiffEqBase  
- Remove unused `using GeometricIntegrators` from test file (replaced with explicit `ArrayPartition` import from RecursiveArrayTools)
- Add ExplicitImports.jl to test dependencies for stale imports checking
- Add RecursiveArrayTools to test dependencies for `ArrayPartition`

## Notes
The `check_no_implicit_imports` test is intentionally skipped because:
- GeometricIntegrators exports vary between versions (0.6.x vs 0.9.x)
- The package uses `using GeometricIntegrators` to get all exports from whichever version is installed
- This is the correct design for supporting multiple major versions

The test does verify that there are no stale explicit imports.

## Test plan
- [x] Package loads correctly
- [x] ExplicitImports stale imports check passes
- [x] No new import issues introduced

**Note:** The existing tests fail due to a pre-existing compatibility issue with newer dependencies (unrelated to this PR). The reshape issue in solve.jl:87 was present before these changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)