### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "sciml"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/GeometricIntegratorsDiffEq.jl
+++ b/src/GeometricIntegratorsDiffEq.jl
@@ -6,27 +6,29 @@ using SciMLBase: ReturnCode
 
 using GeometricIntegrators
 
-const warnkeywords = (:save_idxs, :d_discontinuities, :unstable_check, :save_everystep,
+const warnkeywords = (
+    :save_idxs, :d_discontinuities, :unstable_check, :save_everystep,
     :save_end, :initialize_save, :adaptive, :abstol, :reltol, :dtmax,
     :dtmin, :force_dtmin, :internalnorm, :gamma, :beta1, :beta2,
     :qmax, :qmin, :qsteady_min, :qsteady_max, :qoldinit, :failfactor,
     :maxiters, :isoutofdomain, :unstable_check,
-    :calck, :progress, :tstops, :saveat, :dense)
+    :calck, :progress, :tstops, :saveat, :dense,
+)
 
 function __init__()
-    global warnlist = Set(warnkeywords)
+    return global warnlist = Set(warnkeywords)
 end
 
 include("algorithms.jl")
 include("solve.jl")
 
 export GeometricIntegratorAlgorithm, GIEuler, GIMidpoint, GIHeun2, GIHeun3,
-       GIRalston2, GIRalston3, GIRunge, GIKutta, GIRK4, GIRK416, GIRK438, GISSPRK3,
-       GICrankNicolson, GIKraaijevangerSpijker, GIQinZhang, GICrouzeix,
-       GIImplicitEuler, GIImplicitMidpoint, GISRK3,
-       GIGLRK, GILobattoIIIA, GILobattoIIIB, GILobattoIIIC, GILobattoIIIC̄,
-       GILobattoIIID, GILobattoIIIE, GILobattoIIIF, GIRadauIA, GIRadauIIA,
-       GISymplecticEulerA, GISymplecticEulerB, GILobattoIIIAIIIB,
-       GILobattoIIIBIIIA
+    GIRalston2, GIRalston3, GIRunge, GIKutta, GIRK4, GIRK416, GIRK438, GISSPRK3,
+    GICrankNicolson, GIKraaijevangerSpijker, GIQinZhang, GICrouzeix,
+    GIImplicitEuler, GIImplicitMidpoint, GISRK3,
+    GIGLRK, GILobattoIIIA, GILobattoIIIB, GILobattoIIIC, GILobattoIIIC̄,
+    GILobattoIIID, GILobattoIIIE, GILobattoIIIF, GIRadauIA, GIRadauIIA,
+    GISymplecticEulerA, GISymplecticEulerB, GILobattoIIIAIIIB,
+    GILobattoIIIBIIIA
 
 end # module


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)