### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,9 +19,10 @@ julia = "1.10"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "JET", "ODEProblemLibrary", "Test"]
+test = ["AllocCheck", "ExplicitImports", "JET", "ODEProblemLibrary", "Test"]

--- a/src/GeometricIntegratorsDiffEq.jl
+++ b/src/GeometricIntegratorsDiffEq.jl
@@ -1,10 +1,19 @@
 module GeometricIntegratorsDiffEq
 
-using Reexport
-@reexport using DiffEqBase
-using SciMLBase: ReturnCode
+using Reexport: Reexport, @reexport
+@reexport using DiffEqBase: DiffEqBase
+using SciMLBase: SciMLBase, ReturnCode, check_keywords, isinplace, warn_compat
 
-using GeometricIntegrators
+using GeometricIntegrators:
+    GeometricIntegrators,
+    CrankNicolson, Crouzeix, ExplicitEuler, ExplicitMidpoint,
+    Gauss, Heun2, Heun3, ImplicitEuler, ImplicitMidpoint,
+    KraaijevangerSpijker, Kutta3,
+    LobattoIIIA, LobattoIIIAIIIB, LobattoIIIB, LobattoIIIBIIIA,
+    LobattoIIIC, LobattoIIID, LobattoIIIE, LobattoIIIF,
+    Newton, QinZhang, RK4, RK416, RK438, RadauIA, RadauIIA,
+    Ralston2, Ralston3, Runge2, SRK3, SSPRK3,
+    SymplecticEulerA, SymplecticEulerB, integrate
 
 const warnkeywords = (
     :save_idxs, :d_discontinuities, :unstable_check, :save_everystep,

--- a/test/explicit_imports_test.jl
+++ b/test/explicit_imports_test.jl
@@ -1,0 +1,13 @@
+using ExplicitImports
+using GeometricIntegratorsDiffEq
+using Test
+
+@testset "ExplicitImports" begin
+    @testset "No implicit imports" begin
+        @test check_no_implicit_imports(GeometricIntegratorsDiffEq) === nothing
+    end
+
+    @testset "No stale explicit imports" begin
+        @test check_no_stale_explicit_imports(GeometricIntegratorsDiffEq) === nothing
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using GeometricIntegratorsDiffEq
 using Test
 
-using GeometricIntegrators
+using DiffEqBase: SecondOrderODEProblem, solve
+using SciMLBase: ReturnCode
 import ODEProblemLibrary: prob_ode_2Dlinear
 
 @testset "GeometricIntegratorsDiffEq" begin
@@ -85,6 +86,11 @@ import ODEProblemLibrary: prob_ode_2Dlinear
         @test sol.retcode == ReturnCode.Success
     end
 end # testset GeometricIntegratorsDiffEq
+
+# Run explicit imports tests
+@testset "Explicit Imports" begin
+    include("explicit_imports_test.jl")
+end
 
 # Run allocation tests if AllocCheck is available
 if get(ENV, "GROUP", "All") == "All" || get(ENV, "GROUP", "") == "Nopre"


### PR DESCRIPTION
## Summary

This PR improves explicit imports hygiene for the package by:

- Adding explicit imports for all symbols used from dependencies
- Removing reliance on transitive dependencies  
- Adding ExplicitImports.jl tests to prevent regressions
- Fixing test imports to be explicit about `ReturnCode` and `SecondOrderODEProblem`

## Changes

### Source Code (`src/GeometricIntegratorsDiffEq.jl`)
- All symbols from `GeometricIntegrators`, `SciMLBase`, `DiffEqBase`, and `Reexport` are now explicitly imported
- No more implicit imports or transitive dependencies
- Module structure improved for better clarity

### Tests
- Added explicit imports for `ReturnCode` and `SecondOrderODEProblem` in `test/runtests.jl`
- Created `test/explicit_imports_test.jl` with ExplicitImports.jl checks
- Added ExplicitImports to test dependencies in `Project.toml`

## Verification

Confirmed with ExplicitImports.jl that:
- ✅ No implicit imports remain
- ✅ No stale explicit imports
- ✅ All existing tests pass
- ✅ New ExplicitImports tests pass

This ensures the package follows best practices for dependency management and prevents issues with transitive dependencies.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)