### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricIntegratorsDiffEq"
 uuid = "5a33fad7-5ce4-5983-9f5d-5f26ceab5c96"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -14,7 +14,7 @@ DiffEqBase = "6.62"
 ExplicitImports = "1.14.0"
 GeometricIntegrators = "0.15, 0.16"
 Reexport = "0.2, 1"
-SciMLBase = "2"
+SciMLBase = "2, 3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version to 1.2.0
- No code changes needed - all used SciMLBase types still exist in v3
- Supersedes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)