### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false  # Disabled pending dependency updates - see issue #58
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 [compat]
 DiffEqBase = "6.62, 7"
 ExplicitImports = "1.14.0"
-GeometricIntegrators = "0.15, 0.16"
+GeometricIntegrators = "0.15.5, 0.16"
 Reexport = "0.2, 1"
 SciMLBase = "2, 3"
 SciMLLogging = "1.10.1, 2"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow with `allow_reresolve: false` (genuine test-at-floor: tests run at the minimal/downgraded versions). Raises declared-dep `[compat]` lower bounds: `GeometricIntegrators = "0.15.5, 0.16";`GeometricIntegrators = "0.15.5, 0.16";

Verified locally on Julia 1.10 in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with 0 re-resolve. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)