### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,22 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - "Core"
-          - "NoPre"
-        exclude:
-          - version: "pre"
-            group: "NoPre"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[NoPre]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root **Tests.yml** workflow from a hand-maintained `group × version` matrix into the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the matrix declared once in a root `test/test_groups.toml`.

- `Tests.yml` is converted **in place** (filename and `name: "Tests"` kept) so branch-protection status checks stay stable.
- `on:` triggers and the `concurrency:` block are preserved verbatim.
- The package's `runtests.jl` already dispatches on the standard `GROUP` env var (`Core` / `NoPre`), so **no `with:` inputs are required**: group-env-name (`GROUP`), check-bounds, coverage, and apt-packages are all defaults. Linux-only, so no `os` field (default `ubuntu-latest`).

### New `test/test_groups.toml`

```toml
[Core]
versions = ["lts", "1", "pre"]

[NoPre]
versions = ["lts", "1"]
```

## Matrix match

Old `Tests.yml` matrix was `{Core, NoPre} × {1, lts, pre}` with the `pre`+`NoPre` cell excluded — 5 jobs. Running `compute_affected_sublibraries.jl . --root-matrix` against the new TOML emits exactly:

| group | version |
|-------|---------|
| Core  | lts     |
| Core  | 1       |
| Core  | pre     |
| NoPre | lts     |
| NoPre | 1       |

**5/5 exact match.** All runners `ubuntu-latest`, matching the old default. TOML and YAML both parse cleanly (verified statically).

## QA

Category A: `Core`/`NoPre` GROUP dispatch already exists in `runtests.jl` (ExplicitImports under Core; JET + AllocCheck under NoPre). No `runtests.jl` change and no local Aqua run needed — static matrix verification only. `Project.toml` needed no changes (`[compat] julia = "1.10"` LTS floor present, all deps carry compat, `[extras]`/`[targets].test` aligned). No source bugs surfaced.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)