### PR TITLE
Fix wrong SafeTestsets UUID in [extras]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ julia = "1.10"
 [extras]
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ODEProblemLibrary = "fdc4e326-1af4-4b90-96e7-779fcce2daa5"
-SafeTestsets = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/NoPre/Project.toml
+++ b/test/NoPre/Project.toml
@@ -2,7 +2,7 @@
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 GeometricIntegratorsDiffEq = "5a33fad7-5ce4-5983-9f5d-5f26ceab5c96"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 


### PR DESCRIPTION
## Fix wrong `SafeTestsets` UUID in `[extras]`

Master CI is red on every test job (Core julia 1/lts/pre, NoPre julia 1/lts) and on Downgrade with the same root cause:

```
Unsatisfiable requirements detected for package StaticArraysCore [1e83bf80]:
 StaticArraysCore [1e83bf80] log:
 ├─possible versions are: 1.0.0 - 1.4.4 or uninstalled
 └─restricted to versions [0.0.1, 0.1] by project — no versions left
```

### Root cause

PR #73 ("Use SciMLTesting v1.2 folder-based run_tests") added `SafeTestsets` to `[extras]` with the wrong UUID:

```toml
SafeTestsets = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
```

`1e83bf80-4336-4d27-bf5d-d5a4f845583c` is the UUID of **StaticArraysCore**, not SafeTestsets. Because the name `SafeTestsets` was mapped to StaticArraysCore's UUID, Pkg applied the `[compat]` bound `SafeTestsets = "0.0.1, 0.1"` to StaticArraysCore, whose only registered versions are `1.0.0 - 1.4.4`, making the test environment unsatisfiable.

### Fix

Use SafeTestsets' actual registered UUID:

```toml
SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
```

### Verification

Locally on Julia 1.10 (the package's compat floor), `Pkg.test()` with `GROUP=Core` now resolves the test environment and runs the suite (previously it failed instantly at resolution).

Please ignore until reviewed by @ChrisRackauckas.
