### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricIntegratorsDiffEq"
 uuid = "5a33fad7-5ce4-5983-9f5d-5f26ceab5c96"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.3.1 -> 1.3.2) to release unreleased commits on `master` via JuliaRegistrator.