### PR TITLE
Use SimpleSolvers Newton methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
+SimpleSolvers = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
 
 [compat]
 DiffEqBase = "6.62, 7"
@@ -21,6 +22,7 @@ SafeTestsets = "0.0.1, 0.1"
 SciMLBase = "2, 3"
 SciMLLogging = "1.10.1, 2"
 SciMLTesting = "1.7"
+SimpleSolvers = "0.7, 0.9"
 Test = "1.10"
 julia = "1.10"
 

--- a/src/GeometricIntegratorsDiffEq.jl
+++ b/src/GeometricIntegratorsDiffEq.jl
@@ -5,12 +5,13 @@ using Reexport: Reexport, @reexport
 using SciMLBase: SciMLBase, ReturnCode
 using SciMLLogging: @SciMLMessage
 using RecursiveArrayTools: RecursiveArrayTools
+using SimpleSolvers: SimpleSolvers
 
 using GeometricIntegrators: GeometricIntegrators, CrankNicolson, Crouzeix,
     ExplicitEuler, ExplicitMidpoint, Gauss, Heun2, Heun3, ImplicitEuler,
     ImplicitMidpoint, KraaijevangerSpijker, Kutta3, LobattoIIIA,
     LobattoIIIAIIIB, LobattoIIIB, LobattoIIIBIIIA, LobattoIIIC, LobattoIIID,
-    LobattoIIIE, LobattoIIIF, Newton, QinZhang, RK4, RK416, RK438, RadauIA,
+    LobattoIIIE, LobattoIIIF, QinZhang, RK4, RK416, RK438, RadauIA,
     RadauIIA, Ralston2, Ralston3, Runge2, SRK3, SSPRK3, SymplecticEulerA,
     SymplecticEulerB, integrate
 
@@ -25,6 +26,12 @@ const warnkeywords = (
 
 function __init__()
     return global warnlist = Set(warnkeywords)
+end
+
+newton_solver_method() = if isdefined(SimpleSolvers, :NewtonMethod)
+    SimpleSolvers.NewtonMethod()
+else
+    SimpleSolvers.Newton()
 end
 
 include("algorithms.jl")

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -113,7 +113,7 @@ function SciMLBase.__solve(
 
         ode = GeometricIntegrators.ODEProblem(v!, prob.tspan, dt, vec(prob.u0))
         if needs_solver
-            sol = integrate(ode, _alg; solver = Newton())
+            sol = integrate(ode, _alg; solver = newton_solver_method())
         else
             sol = integrate(ode, _alg)
         end
@@ -164,7 +164,7 @@ function SciMLBase.__solve(
             v!, f!, prob.tspan, dt, vec(prob.u0.x[1]), vec(prob.u0.x[2])
         )
         if needs_solver
-            sol = integrate(pode, _alg; solver = Newton())
+            sol = integrate(pode, _alg; solver = newton_solver_method())
         else
             sol = integrate(pode, _alg)
         end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Stop importing `Newton` from `GeometricIntegrators`, which is no longer defined by `GeometricIntegrators v0.16.4`.
- Add an explicit `SimpleSolvers` dependency and choose the public Newton solver-method constructor that exists in the resolved SimpleSolvers version: `NewtonMethod()` for old 0.7.x downgrade sets, `Newton()` for current 0.9.x sets.
- Continue passing an explicit Newton solver only for methods already marked by `requires_newton_solver`, preserving downgrade behavior where some implicit methods default to `NoSolver`.

## Root cause
`GeometricIntegratorsDiffEq` allowed `GeometricIntegrators = "0.15, 0.16"` in commit `348cb0f`. With `GeometricIntegrators v0.16.4`, `GeometricIntegrators.Newton` is not defined, so precompilation failed at the explicit import in `src/GeometricIntegratorsDiffEq.jl` before tests could run.

A first attempt to rely completely on `GeometricIntegrators.default_solver` fixed v0.16.4 precompile but failed Downgrade CI: the downgraded set resolves `GeometricIntegrators v0.15.5`, `GeometricIntegratorsBase v0.1.11`, and `SimpleSolvers v0.7.10`, where `RadauIA` can still default to `NoSolver`. The final patch uses SimpleSolvers directly and keeps the explicit solver for the affected methods.

## Local verification
- Reproduced on clean `origin/master` at `4882c09` with Julia 1.10: `using GeometricIntegratorsDiffEq` fails with `UndefVarError: Newton not defined` and `isdefined(GeometricIntegrators, :Newton) = false` for `GeometricIntegrators v0.16.4`.
- Fixed branch: exact repro command succeeds with `GeometricIntegrators v0.16.4`, `SimpleSolvers v0.9.1`, `isdefined(GeometricIntegrators, :Newton) = false`, and `GeometricIntegratorsDiffEq.newton_solver_method() = SimpleSolvers.Newton(1)`.
- Current deps: `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'` passed: 32/32 core tests.
- Current deps: `timeout 3600 env GROUP=NoPre /home/crackauc/.juliaup/bin/julia +1.10 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'` passed: JET 29/29, AllocCheck 9/9.
- Current deps: `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'` passed: QA 15/15.
- Downgrade reproduction in a temporary env with `GeometricIntegrators v0.15.5`, `GeometricIntegratorsBase v0.1.11`, `SimpleSolvers v0.7.10`: `include("test/core_tests.jl")` passed: Standard ODE 28/28 and Second Order ODE 4/4.
- Runic check passed with exit code 0.