### PR TITLE
Release prep: bump version to 1.3.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricIntegratorsDiffEq"
 uuid = "5a33fad7-5ce4-5983-9f5d-5f26ceab5c96"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

Bumps the package version from 1.3.2 to 1.3.3. There are three merged PRs since the last release (#77, tagged 1.3.2):

- #78 "Use SciMLTesting 2.1 QA docs check" — widens the `SciMLTesting` test/QA compat from `1.7` to `2.1` and adds `api_docs_kwargs = (; rendered = true)` to the QA run; adds a new `docs/src/index.md` with `@docs` blocks and extensive docstrings for all the `GI*` algorithm structs and `GeometricIntegratorAlgorithm`. Documentation-only from the package's runtime behavior perspective.
- #79 "Use SimpleSolvers Newton methods" — adds a new direct dependency on `SimpleSolvers` (compat `0.7, 0.9`) and swaps the implicit-stage solver from `GeometricIntegrators.Newton()` to a new `newton_solver_method()` helper that uses `SimpleSolvers.NewtonMethod()` when available, falling back to `SimpleSolvers.Newton()` on older `SimpleSolvers` releases. This is an internal solver-backend change; it does not add or remove any exported public API (`Newton` was never re-exported by this package, only used internally).
- Test suite refactor in `test/core_tests.jl` to loop over algorithm lists instead of repeating `solve`/`@test` blocks, plus minor `test/qa/Project.toml` and `test/NoPre/Project.toml` compat cleanup to match the `SciMLTesting` bump.

## Bump type: PATCH (1.3.2 -> 1.3.3)

No new exported symbols or new public API were added — the algorithm struct names in `algorithms.jl` already existed in 1.3.2 and are now just documented. The `SimpleSolvers` swap is an internal implementation/dependency change with a documented-equivalent fallback path, not new user-facing functionality. Per the repo's release policy, this defaults to a PATCH bump.

## Compat bounds

Left as-is. The `SimpleSolvers = "0.7, 0.9"` bound (added in #79) deliberately excludes `0.8.x`, and the source already guards both supported API shapes via `isdefined(SimpleSolvers, :NewtonMethod)`, so the bound is already consistent with the diff. No other SciML-ecosystem compat bounds needed adjustment.